### PR TITLE
Fix type recipes for `Volumes`, `Energies`, `Pressures`, & `BulkModuli`

### DIFF
--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -22,41 +22,41 @@ struct BulkModuli <: Data
     values::Vector
 end
 
-@recipe function f(::Type{Volumes{T}}, volumes::Volumes{T}) where {T}
+@recipe function f(::Type{Volumes}, volumes::Volumes)
     seriestype --> :path
     markershape --> :circle
     markersize --> 2
     markerstrokecolor --> :auto
     markerstrokewidth --> 0
     guide --> "volume"
-    return volumes
+    return volumes.values
 end
-@recipe function f(::Type{Energies{T}}, energies::Energies{T}) where {T}
+@recipe function f(::Type{Energies}, energies::Energies)
     seriestype --> :path
     markershape --> :circle
     markersize --> 2
     markerstrokecolor --> :auto
     markerstrokewidth --> 0
     guide --> "energy"
-    return energies
+    return energies.values
 end
-@recipe function f(::Type{Pressures{T}}, pressures::Pressures{T}) where {T}
+@recipe function f(::Type{Pressures}, pressures::Pressures)
     seriestype --> :path
     markershape --> :circle
     markersize --> 2
     markerstrokecolor --> :auto
     markerstrokewidth --> 0
     guide --> "pressure"
-    return pressures
+    return pressures.values
 end
-@recipe function f(::Type{BulkModuli{T}}, bulkmoduli::BulkModuli{T}) where {T}
+@recipe function f(::Type{BulkModuli}, bulkmoduli::BulkModuli)
     seriestype --> :path
     markershape --> :circle
     markersize --> 2
     markerstrokecolor --> :auto
     markerstrokewidth --> 0
     guide --> "bulk modulus"
-    return bulkmoduli
+    return bulkmoduli.values
 end
 
 @recipe function f(eos::EquationOfStateOfSolids, volumes=eos.param.v0 .* (0.5:0.01:1.1))

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -59,13 +59,32 @@ end
     return bulkmoduli.values
 end
 
-@recipe function f(eos::EquationOfStateOfSolids, volumes=eos.param.v0 .* (0.5:0.01:1.1))
+@recipe function f(eos::EnergyEquation, volumes=eos.param.v0 .* (0.5:0.01:1.1))
+    yvalues = map(eos, volumes)
     framestyle --> :box
     xlims --> extrema(volumes)
+    ylims --> extrema(yvalues)
     legend_foreground_color --> nothing
     grid --> nothing
+    return Volumes(volumes), Energies(yvalues)
+end
+@recipe function f(eos::PressureEquation, volumes=eos.param.v0 .* (0.5:0.01:1.1))
     yvalues = map(eos, volumes)
-    return volumes, yvalues
+    framestyle --> :box
+    xlims --> extrema(volumes)
+    ylims --> extrema(yvalues)
+    legend_foreground_color --> nothing
+    grid --> nothing
+    return Volumes(volumes), Pressures(yvalues)
+end
+@recipe function f(eos::BulkModulusEquation, volumes=eos.param.v0 .* (0.5:0.01:1.1))
+    yvalues = map(eos, volumes)
+    framestyle --> :box
+    xlims --> extrema(volumes)
+    ylims --> extrema(yvalues)
+    legend_foreground_color --> nothing
+    grid --> nothing
+    return Volumes(volumes), BulkModuli(yvalues)
 end
 
 @userplot EnergyPlot

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -168,8 +168,4 @@ end
     end
 end
 
-_yguide(::EnergyEquation) = "energy"
-_yguide(::PressureEquation) = "pressure"
-_yguide(::BulkModulusEquation) = "bulk modulus"
-
 end

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -7,20 +7,19 @@ using Unitful: AbstractQuantity, DimensionError, unit, uconvert, dimension, @u_s
 
 export Volumes, Energies, Pressures, BulkModuli
 
-abstract type Data{T} <: AbstractVector{T} end
+abstract type Data end
 (T::Type{<:Data})(values) = T(collect(values))
-(T::Type{<:Data{S}})(values) where {S} = T(Vector{S}(values))
-struct Volumes{T} <: Data{T}
-    values::Vector{T}
+struct Volumes <: Data
+    values::Vector
 end
-struct Energies{T} <: Data{T}
-    values::Vector{T}
+struct Energies <: Data
+    values::Vector
 end
-struct Pressures{T} <: Data{T}
-    values::Vector{T}
+struct Pressures <: Data
+    values::Vector
 end
-struct BulkModuli{T} <: Data{T}
-    values::Vector{T}
+struct BulkModuli <: Data
+    values::Vector
 end
 
 @recipe function f(::Type{Volumes{T}}, volumes::Volumes{T}) where {T}

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -75,6 +75,13 @@ end
     ylims --> extrema(yvalues)
     legend_foreground_color --> nothing
     grid --> nothing
+    @series begin
+        seriestype --> :hline
+        seriescolor --> :black
+        z_order --> :back
+        label := ""
+        zeros(eltype(yvalues), 1)
+    end
     return Volumes(volumes), Pressures(yvalues)
 end
 @recipe function f(eos::BulkModulusEquation, volumes=eos.param.v0 .* (0.5:0.01:1.1))

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -77,52 +77,13 @@ end
     return bulkmoduli.values
 end
 
-@recipe function f(
-    eos::EquationOfStateOfSolids,
-    volumes=eos.param.v0 .* (0.5:0.01:1.1);
-    xunit=u"angstrom^3",
-    yunit=u"GPa",
-)
-    xguide --> "volume"
-    yguide --> _yguide(eos)
+@recipe function f(eos::EquationOfStateOfSolids, volumes=eos.param.v0 .* (0.5:0.01:1.1))
     framestyle --> :box
     xlims --> extrema(volumes)
     legend_foreground_color --> nothing
     grid --> nothing
     yvalues = map(eos, volumes)
-    x, y = if eltype(volumes) <: AbstractQuantity && eltype(yvalues) <: AbstractQuantity
-        if dimension(xunit) != dimension(eltype(volumes)) ||
-            dimension(yunit) != dimension(eltype(yvalues))
-            error("")
-        else
-            uconvert.(xunit, volumes), uconvert.(yunit, yvalues)
-        end
-    elseif eltype(volumes) <: Real && eltype(yvalues) <: Real
-        volumes, map(eos, volumes)
-    else
-        error("")
-    end
-    if eos isa PressureEquation
-        @series begin
-            seriestype --> :hline
-            seriescolor := :black
-            z_order --> :back
-            primary := false
-            label --> ""
-            zeros(eltype(y), 1)
-        end
-    end
-    @series begin
-        seriestype --> :scatter
-        markersize --> 2
-        markerstrokecolor --> :auto
-        markerstrokewidth --> 0
-        primary := false
-        x, y
-    end
-    seriestype --> :path
-    label --> ""
-    return x, y
+    return volumes, yvalues
 end
 
 @userplot EnergyPlot

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -22,8 +22,26 @@ struct BulkModuli{T} <: DependentVariable{T}
     values::Vector{T}
 end
 
-@recipe f(::Type{Volumes}, 𝐕::Volumes) = 𝐕.values
-@recipe f(::Type{Energies}, 𝐄::Energies) = 𝐄.values
+@recipe function f(::Type{Volumes{T}}, volumes::Volumes) where {T}
+    xguide --> "volume"
+    xlims --> extrema(volumes.values)
+    return volumes.values
+end
+@recipe function f(::Type{Energies{T}}, energies::Energies{T}) where {T}
+    yguide --> "energy"
+    @series begin
+        seriestype --> :scatter
+        markersize --> 2
+        markerstrokecolor --> :auto
+        markerstrokewidth --> 0
+        primary := false
+        energies.values
+    end
+    seriestype --> :path
+    label --> ""
+    return energies.values
+end
+
 @recipe f(::Type{Pressures}, 𝐏::Pressures) = 𝐏.values
 @recipe f(::Type{BulkModuli}, 𝐁::BulkModuli) = 𝐁.values
 

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -5,19 +5,20 @@ using EquationsOfStateOfSolids:
 using RecipesBase: @userplot, @recipe, @series, grid
 using Unitful: AbstractQuantity, DimensionError, unit, uconvert, dimension, @u_str
 
-struct Volumes{T}
+export Volumes, Energies
+
+abstract type IndependentVariable{T} end
+struct Volumes{T} <: IndependentVariable{T}
     values::Vector{T}
 end
-
-struct Energies{T}
+abstract type DependentVariable{T} end
+struct Energies{T} <: DependentVariable{T}
     values::Vector{T}
 end
-
-struct Pressures{T}
+struct Pressures{T} <: DependentVariable{T}
     values::Vector{T}
 end
-
-struct BulkModuli{T}
+struct BulkModuli{T} <: DependentVariable{T}
     values::Vector{T}
 end
 

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -7,18 +7,17 @@ using Unitful: AbstractQuantity, DimensionError, unit, uconvert, dimension, @u_s
 
 export Volumes, Energies, Pressures, BulkModuli
 
-abstract type IndependentVariable{T} end
-struct Volumes{T} <: IndependentVariable{T}
+abstract type Data{T} end
+struct Volumes{T} <: Data{T}
     values::Vector{T}
 end
-abstract type DependentVariable{T} end
-struct Energies{T} <: DependentVariable{T}
+struct Energies{T} <: Data{T}
     values::Vector{T}
 end
-struct Pressures{T} <: DependentVariable{T}
+struct Pressures{T} <: Data{T}
     values::Vector{T}
 end
-struct BulkModuli{T} <: DependentVariable{T}
+struct BulkModuli{T} <: Data{T}
     values::Vector{T}
 end
 

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -33,30 +33,30 @@ end
     return volumes
 end
 @recipe function f(::Type{Energies{T}}, energies::Energies{T}) where {T}
-    yguide --> "energy"
     seriestype --> :path
     markershape --> :circle
     markersize --> 2
     markerstrokecolor --> :auto
     markerstrokewidth --> 0
+    guide --> "energy"
     return energies
 end
 @recipe function f(::Type{Pressures{T}}, pressures::Pressures{T}) where {T}
-    yguide --> "pressure"
     seriestype --> :path
     markershape --> :circle
     markersize --> 2
     markerstrokecolor --> :auto
     markerstrokewidth --> 0
+    guide --> "pressure"
     return pressures
 end
 @recipe function f(::Type{BulkModuli{T}}, bulkmoduli::BulkModuli{T}) where {T}
-    yguide --> "bulk modulus"
     seriestype --> :path
     markershape --> :circle
     markersize --> 2
     markerstrokecolor --> :auto
     markerstrokewidth --> 0
+    guide --> "bulk modulus"
     return bulkmoduli
 end
 

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -23,10 +23,14 @@ struct BulkModuli{T} <: Data{T}
     values::Vector{T}
 end
 
-@recipe function f(::Type{Volumes{T}}, volumes::Volumes) where {T}
-    xguide --> "volume"
-    xlims --> extrema(volumes.values)
-    return volumes.values
+@recipe function f(::Type{Volumes{T}}, volumes::Volumes{T}) where {T}
+    seriestype --> :path
+    markershape --> :circle
+    markersize --> 2
+    markerstrokecolor --> :auto
+    markerstrokewidth --> 0
+    guide --> "volume"
+    return volumes
 end
 @recipe function f(::Type{Energies{T}}, energies::Energies{T}) where {T}
     yguide --> "energy"
@@ -35,7 +39,7 @@ end
     markersize --> 2
     markerstrokecolor --> :auto
     markerstrokewidth --> 0
-    return energies.values
+    return energies
 end
 @recipe function f(::Type{Pressures{T}}, pressures::Pressures{T}) where {T}
     yguide --> "pressure"
@@ -44,7 +48,7 @@ end
     markersize --> 2
     markerstrokecolor --> :auto
     markerstrokewidth --> 0
-    return pressures.values
+    return pressures
 end
 @recipe function f(::Type{BulkModuli{T}}, bulkmoduli::BulkModuli{T}) where {T}
     yguide --> "bulk modulus"
@@ -53,7 +57,7 @@ end
     markersize --> 2
     markerstrokecolor --> :auto
     markerstrokewidth --> 0
-    return bulkmoduli.values
+    return bulkmoduli
 end
 
 @recipe function f(eos::EquationOfStateOfSolids, volumes=eos.param.v0 .* (0.5:0.01:1.1))

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -7,7 +7,9 @@ using Unitful: AbstractQuantity, DimensionError, unit, uconvert, dimension, @u_s
 
 export Volumes, Energies, Pressures, BulkModuli
 
-abstract type Data{T} end
+abstract type Data{T} <: AbstractVector{T} end
+(T::Type{<:Data})(values) = T(collect(values))
+(T::Type{<:Data{S}})(values) where {S} = T(Vector{S}(values))
 struct Volumes{T} <: Data{T}
     values::Vector{T}
 end
@@ -105,5 +107,13 @@ end
         volumes, yvalues
     end
 end
+
+Base.size(data::Data) = size(data.values)
+
+Base.IndexStyle(::Type{<:Data}) = IndexLinear()
+
+Base.getindex(data::Data, i) = getindex(data.values, i)
+
+Base.setindex!(data::Data, value, i) = getindex(data.values, value, i)
 
 end

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -111,12 +111,4 @@ end
     end
 end
 
-Base.size(data::Data) = size(data.values)
-
-Base.IndexStyle(::Type{<:Data}) = IndexLinear()
-
-Base.getindex(data::Data, i) = getindex(data.values, i)
-
-Base.setindex!(data::Data, value, i) = getindex(data.values, value, i)
-
 end

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -29,51 +29,29 @@ end
 end
 @recipe function f(::Type{Energies{T}}, energies::Energies{T}) where {T}
     yguide --> "energy"
-    @series begin
-        seriestype --> :scatter
-        markersize --> 2
-        markerstrokecolor --> :auto
-        markerstrokewidth --> 0
-        primary := false
-        energies.values
-    end
     seriestype --> :path
-    label --> ""
+    markershape --> :circle
+    markersize --> 2
+    markerstrokecolor --> :auto
+    markerstrokewidth --> 0
     return energies.values
 end
 @recipe function f(::Type{Pressures{T}}, pressures::Pressures{T}) where {T}
     yguide --> "pressure"
-    @series begin
-        seriestype --> :hline
-        seriescolor := :black
-        z_order --> :back
-        primary := false
-        zeros(T, 1)
-    end
-    @series begin
-        seriestype --> :scatter
-        markersize --> 2
-        markerstrokecolor --> :auto
-        markerstrokewidth --> 0
-        primary := false
-        pressures.values
-    end
     seriestype --> :path
-    label --> ""
+    markershape --> :circle
+    markersize --> 2
+    markerstrokecolor --> :auto
+    markerstrokewidth --> 0
     return pressures.values
 end
 @recipe function f(::Type{BulkModuli{T}}, bulkmoduli::BulkModuli{T}) where {T}
     yguide --> "bulk modulus"
-    @series begin
-        seriestype --> :scatter
-        markersize --> 2
-        markerstrokecolor --> :auto
-        markerstrokewidth --> 0
-        primary := false
-        bulkmoduli.values
-    end
     seriestype --> :path
-    label --> ""
+    markershape --> :circle
+    markersize --> 2
+    markerstrokecolor --> :auto
+    markerstrokewidth --> 0
     return bulkmoduli.values
 end
 

--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -5,7 +5,7 @@ using EquationsOfStateOfSolids:
 using RecipesBase: @userplot, @recipe, @series, grid
 using Unitful: AbstractQuantity, DimensionError, unit, uconvert, dimension, @u_str
 
-export Volumes, Energies
+export Volumes, Energies, Pressures, BulkModuli
 
 abstract type IndependentVariable{T} end
 struct Volumes{T} <: IndependentVariable{T}
@@ -41,9 +41,41 @@ end
     label --> ""
     return energies.values
 end
-
-@recipe f(::Type{Pressures}, 𝐏::Pressures) = 𝐏.values
-@recipe f(::Type{BulkModuli}, 𝐁::BulkModuli) = 𝐁.values
+@recipe function f(::Type{Pressures{T}}, pressures::Pressures{T}) where {T}
+    yguide --> "pressure"
+    @series begin
+        seriestype --> :hline
+        seriescolor := :black
+        z_order --> :back
+        primary := false
+        zeros(T, 1)
+    end
+    @series begin
+        seriestype --> :scatter
+        markersize --> 2
+        markerstrokecolor --> :auto
+        markerstrokewidth --> 0
+        primary := false
+        pressures.values
+    end
+    seriestype --> :path
+    label --> ""
+    return pressures.values
+end
+@recipe function f(::Type{BulkModuli{T}}, bulkmoduli::BulkModuli{T}) where {T}
+    yguide --> "bulk modulus"
+    @series begin
+        seriestype --> :scatter
+        markersize --> 2
+        markerstrokecolor --> :auto
+        markerstrokewidth --> 0
+        primary := false
+        bulkmoduli.values
+    end
+    seriestype --> :path
+    label --> ""
+    return bulkmoduli.values
+end
 
 @recipe function f(
     eos::EquationOfStateOfSolids,


### PR DESCRIPTION
Much more elegant way of doing it.

See:

- https://discourse.julialang.org/t/what-is-the-usage-of-type-recipes-in-recipesbase-jl-plots-jl/92985
- https://discourse.julialang.org/t/what-if-we-have-one-type-recipe-for-the-x-axis-and-one-for-the-y-axis/93563
- https://discourse.julialang.org/t/how-to-add-a-new-series-within-a-type-recipe/93561/2