### PR TITLE
Deprecate adding the lowest point in `plot` for `EnergyEquation`

### DIFF
--- a/src/EquationOfStateRecipes.jl
+++ b/src/EquationOfStateRecipes.jl
@@ -65,22 +65,7 @@ plot
 
 @recipe function f(eos::EnergyEquation, volumes=eos.param.v0 .* (0.5:0.01:1.1))
     energies = map(eos, volumes)
-    min, index = findmin(energies)
-    xguide --> "volume"  # We have to add this since `Volumes` & `Energies` are not the last to return.
-    yguide --> "energy"
-    # We have to add the curves before the scatter, so that the labels and colors are followed correctly.
-    @series begin
-        seriestype --> :path
-        Volumes(volumes), Energies(energies)
-    end
-    @series begin  # The scatter is not a primary series, so it won't be included in the legend.
-        primary := false  # See https://discourse.julialang.org/t/what-does-the-primary-attribute-do-and-how-to-plot-curves-with-scatters-added-onto-it-in-plots-jl/93486/2
-        seriestype --> :scatter
-        markersize --> 1.25 * get(plotattributes, :linewidth, 1)
-        markerstrokewidth --> 0
-        label --> ""
-        [volumes[index]], [min]
-    end
+    return Volumes(volumes), Energies(energies)
 end
 @recipe function f(eos::PressureEquation, volumes=eos.param.v0 .* (0.5:0.01:1.1))
     pressures = map(eos, volumes)


### PR DESCRIPTION
Because the lowest point might not be in our input data